### PR TITLE
refactor so get customer list accepts path argument

### DIFF
--- a/app/customer.py
+++ b/app/customer.py
@@ -66,7 +66,7 @@ class Customer(object):
         return self.__active
 
     def get_customer_list(db_path):
-        """ Returns a list of tuples with each tuple being a customer from the database.
+        """ Returns a list of tuples with each tuple being a customer from the database. The db_path argument allows this method to be called from different execution contexts and still connect to the database with the correct path.
         """
         # Connect to the database
         with sqlite3.connect(db_path) as conn:

--- a/app/customer.py
+++ b/app/customer.py
@@ -65,11 +65,11 @@ class Customer(object):
         """
         return self.__active
 
-    def get_customer_list():
+    def get_customer_list(db_path):
         """ Returns a list of tuples with each tuple being a customer from the database.
         """
         # Connect to the database
-        with sqlite3.connect('../bangazon.db') as conn:
+        with sqlite3.connect(db_path) as conn:
             c = conn.cursor()
             # select all customers, but only getch id and name
             c.execute("SELECT customerId, customer_name FROM Customers")

--- a/tests/test_register_customer.py
+++ b/tests/test_register_customer.py
@@ -45,7 +45,7 @@ class TestRegisterCustomer(unittest.TestCase):
         """
         This method tests if a list of tuples is returned when asking for a list of customers.
         """
-        customers = Customer.get_customer_list()
+        customers = Customer.get_customer_list('../bangazon.db')
         self.assertIsInstance(customers, list)
         self.assertIsInstance(customers[0], tuple)
 


### PR DESCRIPTION
# Description
This fix allows get_customer_list to be invoked from different execution contexts.

## Number of Fixes
1

## Related Ticket(s)
#1 #5 
## Problem to Solve
At issue was that the test and place where get_customer_list was invoked required the path to the database to be different.

## Proposed Changes
I added an argument for the database path

## Expected Behavior
All tests should still pass

## Steps to Test Solution

1. fetch this branch
1. go into `tests` and run `python runtests.py`.

All tests should still pass.

## Testing

[ ] There are new unit tests in this PR, and I verify that there is full coverage of all new code.
[x] I certify that all existing tests pass

## Documentation
[ ] There is new documentation in this pull request that must be reviewed..
[x] I added documentation for any new classes/methods

## Deploy Notes
none