### PR TITLE
CLI: Add Customer Payment Type

### DIFF
--- a/app/paymentmanager.py
+++ b/app/paymentmanager.py
@@ -21,7 +21,7 @@ class PaymentManager():
                     account_number - account number of payment type
         """
 
-        with sqlite3.connect("../bangazon.db") as bangazon:
+        with sqlite3.connect("bangazon.db") as bangazon:
             c = bangazon.cursor()
 
             c.execute("SELECT customerId FROM Customers WHERE active = 1")
@@ -53,7 +53,7 @@ class PaymentManager():
                     customer - customer to get payment types for
         """
 
-        with sqlite3.connect("../bangazon.db") as bangazon:
+        with sqlite3.connect("bangazon.db") as bangazon:
             c = bangazon.cursor()
 
             c.execute("SELECT customerId FROM Customers WHERE active = 1")

--- a/cli_modules/create_payment.py
+++ b/cli_modules/create_payment.py
@@ -1,4 +1,60 @@
+import sys
+sys.path.append('../')
+
+from app.paymentmanager import *
+from app.customerstatusmanager import *
+from app.customer import *
+
+class bcolors:
+    """
+        The bcolors class variables relevant to adding color to the command line interface.
+
+        Resource: 'http://stackoverflow.com/questions/287871/print-in-terminal-with-colors-using-python'
+
+    """
+    HEADER = '\033[95m'
+    OKBLUE = '\033[94m'
+    OKGREEN = '\033[92m'
+    WARNING = '\033[93m'
+    FAIL = '\033[91m'
+    ENDC = '\033[0m'
+    BOLD = '\033[1m'
+    UNDERLINE = '\033[4m'
+
 class CLICreatePayment():
+    """
+        The CLICreatePayment class contains all methods and properties related to the command line interface actions of adding payment methods to a customer's account.
+
+        Methods: 
+                - create_payment
+
+        Author: Steven Holmes (Python Ponies [Bangazon, LLC])
+    """
 
     def create_payment():
-        print("you typed 3")
+        """
+            Creates a payment for the user via command line interface and adds it to the Bangazon database.
+
+        """
+
+        payment = PaymentManager()
+
+        print(bcolors.HEADER + """
+            *****************************************
+            *       CREATE NEW PAYMENT TYPE         *
+            *****************************************
+            """)
+        payment_name = input(bcolors.OKBLUE + """
+
+            Enter payment type (e.g. AmEx, Visa, Checking)
+
+            -->""")
+        account_number = input("""
+
+            Enter account number
+
+            -->""")
+        # payment.add_payment_type(payment_name, account_number)
+
+        print(bcolors.WARNING + 'Successfully added ' + payment_name + ' payment to your account. Account #: ' + account_number)
+

--- a/cli_modules/create_payment.py
+++ b/cli_modules/create_payment.py
@@ -44,13 +44,13 @@ class CLICreatePayment():
             *      CREATE NEW PAYMENT TYPE          *
             *****************************************
             """)
-        payment_name = input(bcolors.OKGREEN + """
+        payment_name = input(bcolors.OKBLUE + """
 
             Enter payment type (e.g. AmEx, Visa, Checking)
 
             > """ + bcolors.ENDC)
 
-        account_number = input(bcolors.OKGREEN + """
+        account_number = input(bcolors.OKBLUE + """
 
             Enter account number
 
@@ -58,5 +58,5 @@ class CLICreatePayment():
 
         payment.add_payment_type(payment_name, account_number)
 
-        print(bcolors.WARNING + 'Successfully added ' + payment_name + ' (#' + account_number + ') payment method to your account.')
+        print(bcolors.OKBLUE + 'Successfully added ' + payment_name + ' (#' + account_number + ') payment method to your account.')
 

--- a/cli_modules/create_payment.py
+++ b/cli_modules/create_payment.py
@@ -7,7 +7,7 @@ from app.customer import *
 
 class bcolors:
     """
-        The bcolors class variables relevant to adding color to the command line interface.
+        The bcolors class contains variables relevant to adding color to the command line interface.
 
         Resource: 'http://stackoverflow.com/questions/287871/print-in-terminal-with-colors-using-python'
 

--- a/cli_modules/create_payment.py
+++ b/cli_modules/create_payment.py
@@ -39,7 +39,7 @@ class CLICreatePayment():
 
         payment = PaymentManager()
 
-        print(bcolors.HEADER + """
+        print("""
             *****************************************
             *      CREATE NEW PAYMENT TYPE          *
             *****************************************
@@ -48,13 +48,13 @@ class CLICreatePayment():
 
             Enter payment type (e.g. AmEx, Visa, Checking)
 
-            --> """ + bcolors.ENDC)
+            > """ + bcolors.ENDC)
 
         account_number = input(bcolors.OKGREEN + """
 
             Enter account number
 
-            --> """ + bcolors.ENDC)
+            > """ + bcolors.ENDC)
 
         payment.add_payment_type(payment_name, account_number)
 

--- a/cli_modules/create_payment.py
+++ b/cli_modules/create_payment.py
@@ -48,13 +48,14 @@ class CLICreatePayment():
 
             Enter payment type (e.g. AmEx, Visa, Checking)
 
-            -->""")
+            --> """)
         account_number = input("""
 
             Enter account number
 
-            -->""")
-        # payment.add_payment_type(payment_name, account_number)
+            --> """)
+
+        payment.add_payment_type(payment_name, account_number)
 
         print(bcolors.WARNING + 'Successfully added ' + payment_name + ' payment to your account. Account #: ' + account_number)
 

--- a/cli_modules/create_payment.py
+++ b/cli_modules/create_payment.py
@@ -41,21 +41,22 @@ class CLICreatePayment():
 
         print(bcolors.HEADER + """
             *****************************************
-            *       CREATE NEW PAYMENT TYPE         *
+            *      CREATE NEW PAYMENT TYPE          *
             *****************************************
             """)
-        payment_name = input(bcolors.OKBLUE + """
+        payment_name = input(bcolors.OKGREEN + """
 
             Enter payment type (e.g. AmEx, Visa, Checking)
 
-            --> """)
-        account_number = input("""
+            --> """ + bcolors.ENDC)
+
+        account_number = input(bcolors.OKGREEN + """
 
             Enter account number
 
-            --> """)
+            --> """ + bcolors.ENDC)
 
         payment.add_payment_type(payment_name, account_number)
 
-        print(bcolors.WARNING + 'Successfully added ' + payment_name + ' payment to your account. Account #: ' + account_number)
+        print(bcolors.WARNING + 'Successfully added ' + payment_name + ' (#' + account_number + ') payment method to your account.')
 


### PR DESCRIPTION
# Description
This pull request proposes merging new code into the following file(s):
- paymentmanager.py
- create_payment.py

The code that has been added fulfills the requirement of allowing the customer user to add a payment method to their account via the command line interface that we are constructing. 

## Number of Fixes
1 fix. 

## Related Ticket(s)
#1 + #10 

## Problem to Solve
This PR solves the following:

- Allows customer user to use the command line interface to add a Payment Type (Visa, MasterCard, etc.) and corresponding account number to their Bangazon account. 

## Proposed Changes
- Added logic to fulfill requirements using the 'input' method to get information from customer user. 

## Expected Behavior
Customer user should now be able to use the command line to add a payment method to their account once that have 'activated' a user that will be used during their shopping session. 

## Steps to Test Solution

1. git fetch
2. git checkout swh-cli
3. rm -rf bangazon.db [if exists]
4. python main.py
5. python bangazon.py 3
6. ensure that this aspect of the interface functions properly and that the database updates according to user input.

## Testing

[ ] There are new unit tests in this PR, and I verify that there is full coverage of all new code.
[ ] I certify that all existing tests pass

## Documentation
[x] There is new documentation in this pull request that must be reviewed..
[x] I added documentation for any new classes/methods

## Deploy Notes
N/A