### PR TITLE
CLI: Return User To Main Menu After Adding Payment

### DIFF
--- a/cli_modules/create_payment.py
+++ b/cli_modules/create_payment.py
@@ -58,5 +58,18 @@ class CLICreatePayment():
 
         payment.add_payment_type(payment_name, account_number)
 
-        print(bcolors.OKBLUE + 'Successfully added ' + payment_name + ' (#' + account_number + ') payment method to your account.')
+        print(bcolors.OKBLUE + 'Successfully added ' + payment_name + ' (#' + account_number + ') payment method to your account.' + bcolors.ENDC)
+
+        print("""
+            *********************************************************
+            **  Welcome to Bangazon! Command Line Ordering System  **
+            *********************************************************
+            1. Create a customer account
+            2. Choose active customer
+            3. Create a payment option
+            4. Add product to shopping cart
+            5. Complete an order
+            7. Leave Bangazon!
+        """
+        )
 


### PR DESCRIPTION
# Description
This is a simple PR that fixes one issue in 'create_payment.py'

## Number of Fixes
1

## Related Ticket(s)
#1 + #10

## Problem to Solve
When the customer user completes the process of adding a payment type to their account. 

## Proposed Changes
Added a print statement to the end of the file to display the full menu to the user. 

## Steps to Test Solution

1. git fetch
2. git checkout swh-cli-fixes
3. rm -rf bangazon.db
4. python main.py
5. python bangazon.py 3
6. complete process
7. ensure that main menu is displayed upon process completion

## Testing

[ ] There are new unit tests in this PR, and I verify that there is full coverage of all new code.
[ ] I certify that all existing tests pass

## Documentation
[ ] There is new documentation in this pull request that must be reviewed..
[ ] I added documentation for any new classes/methods

## Deploy Notes
N/A