### PR TITLE
error handling for zip code as number when registering customer

### DIFF
--- a/cli_modules/create_customer.py
+++ b/cli_modules/create_customer.py
@@ -16,13 +16,23 @@ class CLICreateCustomer():
         '''
 
         # collect user inputs
-        customer_name  = input(" Enter customer name > ")
+        customer_name  = input("Enter customer name  > ")
         street_address = input("Enter street address > ")
-        city           = input("          Enter city > ")
-        state          = input("         Enter state > ")
-        postal_code    = input("   Enter postal code > ")
-        phone_number   = input("  Enter phone number > ")
+        city           = input("Enter city           > ")
+        state          = input("Enter state          > ")
+        print                 ("(enter number only)")
+        postal_code    = input("Enter postal code    > ")
 
+        # only allow numbers when asking for postal code
+        while postal_code.isdigit() == False:
+            print              ("")
+            print              ("ERROR")
+            print              ("(enter number only)")
+            postal_code = input("Enter postal code    > ")
+
+        phone_number   = input ("Enter phone number   > ")
+
+        # create new customer based on inputs
         new_customer = Customer(
             customer_name,
             street_address,


### PR DESCRIPTION
# Description
A customer is forced to type a number for zip code.

## Number of Fixes
1

## Related Ticket(s)
#1 #4

## Problem to Solve
When you register a customer, an error was thrown if you didn't type an integer for the zip code so an error isn't thrown since zip code needs to be an integer to be pushed to the database.

## Proposed Changes
With error handling, a user can only add a number to zipcode.

## Expected Behavior
All tests but 2 should pass. An upcoming PR addresses the next 2 failing tests.

## Steps to Test Solution

1. git fetch this branch.
1. in `tests` run `python runtests.py`

All tests but 2 will pass.

1. From the root, run `python bangazon.py 1` to register a user.
1. Test using a number in zipcode and then not using a number in zipcode.
1. You can continue to not type a number multiple times until you type a number.

## Testing

[ ] There are new unit tests in this PR, and I verify that there is full coverage of all new code.
[ ] I certify that all existing tests pass

## Documentation
[ ] There is new documentation in this pull request that must be reviewed..
[ ] I added documentation for any new classes/methods

## Deploy Notes
none